### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 angular-masonry-fly
 -------------------
-####Generates masonry layout image by image without knowing their height or waiting for all images to load.
+#### Generates masonry layout image by image without knowing their height or waiting for all images to load.
 
 + Works with infinite scroll and window resizing.
 + No need to know images height or wait for all images to download.
 + Can be used on same page on different containers(***new***)
 
-#####DEMO
+##### DEMO
 http://bimal1331.github.io/angular-masonry-fly
 
-#####REQUIREMENTS
+##### REQUIREMENTS
 + Angularjs 1.2+ only
 
-#####INSTALLATION
+##### INSTALLATION
 + Download angular-masonry.min.js and include it with your JS files.
 + Include module ***masonryLayout*** in your main app module.
 
@@ -20,7 +20,7 @@ or
 
 use [Bower](http://bower.io/) to install `bower install angular-masonry-fly`
 
-#####USAGE
+##### USAGE
 
 + Use directive ***data-masonry*** like below -
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
